### PR TITLE
Simplify attack script now that phoenixAES bug is fixed in 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ To run the full attack:
 $ make
 $ ./attack.sh
 ```
+
+Make sure to use at least v0.0.4 of phoenixAES.

--- a/attack_hack_ches21.py
+++ b/attack_hack_ches21.py
@@ -9,24 +9,10 @@ sys.stdout = sys.stderr
 print("[+] DFA on 13th round\n")
 subkey13 = phoenixAES.crack_file("tracefile_r11", verbose=0)
 
-# 10th round fault c
-# onversion
 print("[+] DFA on 12th round\n")
-lastroundkey = unhexlify(subkey13)
-with open("tracefile_r10", "r") as faulted_file:
-    faulted = faulted_file.read().strip().split("\n")
+subkey12 = phoenixAES.crack_file("tracefile_r10", lastroundkeys=[unhexlify(subkey13)], verbose=0)
 
-# Rewind one round with round key found
-with open("tracefile_r10_convert", "w") as faulted_file:
-    for i in faulted:
-        final_state = unhexlify(i)
-        previous_state = bytes(phoenixAES.rewind(final_state,lastroundkeys=[lastroundkey], encrypt=True, mimiclastround=True))
-        faulted_file.write(hexlify(previous_state).decode() + "\n")
-
-subkey12 = phoenixAES.crack_file("tracefile_r10_convert", verbose=0)
-subkey12 = unhexlify(subkey12)
 print()
-
 # Restore stdout
 sys.stdout = sys.__stdout__
-print(hexlify(phoenixAES.MC(subkey12) + lastroundkey[0:8]).decode())
+print(subkey12 + subkey13[0:16])


### PR DESCRIPTION
phoenixAES crack_file has an option  to deal with lastroundkeys to crack previous rounds
But there was a bug (forgot to rewind the ref), which is now fixed in phoenixAES v0.0.4
So now you can enjoy a much simpler attack script :)
