### PR TITLE
Fault simulation: fix display of plaintext and add display of ciphertext

### DIFF
--- a/simu/veriraptor.cpp
+++ b/simu/veriraptor.cpp
@@ -195,16 +195,20 @@ int main(int argc, char ** argv)
     }
 
     std::cout << "\nUsing plaintext:\n";
-    for (i=4;i>=0;i--) {
+    for (i=3;i>=0;i--) {
         top->state[i] = g1();
         std::cout << std::setw(8) << std::setfill('0') << std::hex << top->state[i];
     }
-    std::cout << "\n\n";
-    
+
     fault_file.open("tracefile_r11");
 
     // Golden sample
     aes_encrypt(top);
+    std::cout << "\nGetting ciphertext:\n";
+    for (i=3;i>=0;i--) {
+        std::cout << std::setw(8) << std::setfill('0') << std::hex << top->out[i];
+    }
+    std::cout << "\n\n";
     write_result(top, fault_file, verbose);
 
     // Getting the faults in round 11


### PR DESCRIPTION
Strangely it fixes also display of last 4 bytes of recovered last round key...

I was tracking the following problem:
```
./attack.sh
[+] Fault simulation with Verilator
Using key:
59c99bb1c9b380606e03309bb5167b9797bba2d7bd29b174
Using plaintext:
5843df1aa0f2ffa70032111851bf97890133a45f
...
Last round key #N found:
EDF6E5701267B130EF97DD658DF296E0
...
K12: EDF6E5701267B130EF97DD65D5B149FA
```
See, last 4 bytes of K12 are different from the recovered last round key.

When validating the key with openssl, I noticed plaintext display was wrong, too long.
That's because the loop iterates from 4, which provokes also the injection of a random 32b to top->state[4], overwriting I don't know what but supposed to be initialized at 0x00000000 and this provokes the corruption of last round key last bytes (which was unnoticed because not used when reverting AES192 keyschedule).

So now, plaintext display is fixed, I also added ciphertext display to ease validation, and incidentally last round key display is fixed too.
```
./attack.sh
[+] Fault simulation with Verilator
Using key:
818e4d6572a3c5efaba4c88656928011edab801f0c2ad6f9
Using plaintext:
d9b504d34e8575b828f6879de980b15a
Getting ciphertext:
e5447ed9b2e1e9259040943d88c71011
...
Last round key #N found:
5BB809C200E58EB1A70AA01D2B5F30B0
K12: 5BB809C200E58EB1A70AA01D2B5F30B0
```
